### PR TITLE
Feature wi fi direct add ap ifor gps

### DIFF
--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Develop/SecretActivity.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Develop/SecretActivity.java
@@ -30,7 +30,7 @@ public class SecretActivity extends Activity {
     SyugoApp app;
 
     // ui
-    Button ping_button;
+    Button chat_button,loc_button;
     CompoundButton wfd_button;
 
     @Override
@@ -40,24 +40,34 @@ public class SecretActivity extends Activity {
         app = (SyugoApp) getApplication();
         wfd = new WiFiDirect(SecretActivity.this);
 
-        //reset savedata
-        ping_button = (Button) findViewById(R.id.sc_ping);
-        ping_button.setOnClickListener(new View.OnClickListener() {
+        //test button
+        chat_button = (Button) findViewById(R.id.sc_chat);
+        chat_button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 wfd.sendChat("hoge");
+            }
+        });
+        loc_button = (Button) findViewById(R.id.sc_loc);
+        loc_button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
                 wfd.sendGPSLocation(new LocationData(1.2,1.4,1.5));
             }
         });
+
+
         wfd.setWiFiDirectEventListener(new WiFiDirectEventListener() {
             @Override
             public void receiveChat(String str) {
                 wfd.toast(str);
+                Log.d(TAG,str);
             }
 
             @Override
             public void receiveGPSLocation(LocationData loc) {
-                wfd.toast(loc.toString());
+                wfd.toast(loc.dump());
+                Log.d(TAG,loc.dump());
             }
         });
 

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Develop/SecretActivity.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Develop/SecretActivity.java
@@ -15,6 +15,7 @@ import jp.enpitsu.paseri.syugo.R;
 import jp.enpitsu.paseri.syugo.Rader.LocationData;
 import jp.enpitsu.paseri.syugo.Start.StartActivity;
 import jp.enpitsu.paseri.syugo.WiFiDirect.WiFiDirect;
+import jp.enpitsu.paseri.syugo.WiFiDirect.WiFiDirectEventListener;
 
 /**
  * Created by Prily on 2016/12/01.
@@ -46,6 +47,17 @@ public class SecretActivity extends Activity {
             public void onClick(View v) {
                 wfd.sendChat("hoge");
                 wfd.sendGPSLocation(new LocationData(1.2,1.4,1.5));
+            }
+        });
+        wfd.setWiFiDirectEventListener(new WiFiDirectEventListener() {
+            @Override
+            public void receiveChat(String str) {
+                wfd.toast(str);
+            }
+
+            @Override
+            public void receiveGPSLocation(LocationData loc) {
+                wfd.toast(loc.toString());
             }
         });
 

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Develop/SecretActivity.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Develop/SecretActivity.java
@@ -12,6 +12,7 @@ import android.widget.ToggleButton;
 
 import jp.enpitsu.paseri.syugo.Global.SyugoApp;
 import jp.enpitsu.paseri.syugo.R;
+import jp.enpitsu.paseri.syugo.Rader.LocationData;
 import jp.enpitsu.paseri.syugo.Start.StartActivity;
 import jp.enpitsu.paseri.syugo.WiFiDirect.WiFiDirect;
 
@@ -28,7 +29,7 @@ public class SecretActivity extends Activity {
     SyugoApp app;
 
     // ui
-    Button reset_button;
+    Button ping_button;
     CompoundButton wfd_button;
 
     @Override
@@ -39,11 +40,12 @@ public class SecretActivity extends Activity {
         wfd = new WiFiDirect(SecretActivity.this);
 
         //reset savedata
-        reset_button = (Button) findViewById(R.id.sc_data_reset);
-        reset_button.setOnClickListener(new View.OnClickListener() {
+        ping_button = (Button) findViewById(R.id.sc_ping);
+        ping_button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                app.resetUserInfo();
+                wfd.sendMessage("hoge");
+                wfd.sendGPSLocation(new LocationData(1.2,1.4,1.5));
             }
         });
 

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Develop/SecretActivity.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Develop/SecretActivity.java
@@ -88,4 +88,10 @@ public class SecretActivity extends Activity {
         wfd.onPause();
     }
 
+    @Override
+    public void onDestroy(){
+        super.onDestroy();
+        wfd.onDestroy();
+    }
+
 }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Develop/SecretActivity.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Develop/SecretActivity.java
@@ -44,7 +44,7 @@ public class SecretActivity extends Activity {
         ping_button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                wfd.sendMessage("hoge");
+                wfd.sendChat("hoge");
                 wfd.sendGPSLocation(new LocationData(1.2,1.4,1.5));
             }
         });

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Rader/LocationData.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Rader/LocationData.java
@@ -12,8 +12,16 @@ public class LocationData {
         this.lon = lon;
         this.acc = acc;
     }
-    public byte[] getBytes(){
-        int size = Double.SIZE/8 * 3;
+
+    public LocationData( byte[] bytes ) {
+        int size = Double.SIZE / 8 * 3;
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        this.lat = buffer.getDouble();
+        this.lon = buffer.getDouble();
+        this.acc = buffer.getDouble();
+    }
+    public byte[] getBytes() {
+        int size = Double.SIZE / 8 * 3;
         ByteBuffer buffer = ByteBuffer.allocate(size);
         buffer.clear();
         buffer.putDouble(lat);

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Rader/LocationData.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Rader/LocationData.java
@@ -1,5 +1,7 @@
 package jp.enpitsu.paseri.syugo.Rader;
 
+import java.nio.ByteBuffer;
+
 /**
  * Created by soniyama on 2016/08/29.
  */
@@ -9,5 +11,14 @@ public class LocationData {
         this.lat = lat;
         this.lon = lon;
         this.acc = acc;
+    }
+    public byte[] getBytes(){
+        int size = Double.SIZE/8 * 3;
+        ByteBuffer buffer = ByteBuffer.allocate(size);
+        buffer.clear();
+        buffer.putDouble(lat);
+        buffer.putDouble(lon);
+        buffer.putDouble(acc);
+        return buffer.array();
     }
 }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Rader/LocationData.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Rader/LocationData.java
@@ -1,6 +1,8 @@
 package jp.enpitsu.paseri.syugo.Rader;
 
 
+import java.nio.ByteBuffer;
+
 /**
  * Created by soniyama on 2016/08/29.
  */
@@ -21,6 +23,28 @@ public class LocationData {
         this.lon  = lon;
         this.acc  = acc;
         this.gettime = gettime;
+    }
+
+    // for Serializer
+    public LocationData( byte[] bytes ) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        this.lat = buffer.getDouble();
+        this.lon = buffer.getDouble();
+        this.acc = buffer.getDouble();
+        this.gettime = buffer.getLong();
+    }
+    public byte[] getBytes() {
+        int size = Double.SIZE / 8 * 3 + Long.SIZE/8;
+        ByteBuffer buffer = ByteBuffer.allocate(size);
+        buffer.clear();
+        buffer.putDouble(lat);
+        buffer.putDouble(lon);
+        buffer.putDouble(acc);
+        buffer.putLong(gettime);
+        return buffer.array();
+    }
+    public String dump() {
+        return String.valueOf(lat) + " , " + String.valueOf(lon) + " , " + String.valueOf(acc) + " , " + String.valueOf(gettime);
     }
 
 }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Rader/LocationData.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Rader/LocationData.java
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer;
  * Created by soniyama on 2016/08/29.
  */
 public class LocationData {
-    double lat, lon, acc;
+    public double lat, lon, acc;
     public LocationData( double lat, double lon, double acc ) {
         this.lat = lat;
         this.lon = lon;
@@ -28,5 +28,8 @@ public class LocationData {
         buffer.putDouble(lon);
         buffer.putDouble(acc);
         return buffer.array();
+    }
+    public String dump() {
+        return String.valueOf(lat) + " , " + String.valueOf(lon) + " , " + String.valueOf(acc);
     }
 }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Rader/RaderActivity.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Rader/RaderActivity.java
@@ -394,6 +394,12 @@ public class RaderActivity extends Activity {
         wfd.onPause();
     }
 
+    @Override
+    protected void onDestroy(){
+        super.onPause();
+        wfd.onDestroy();
+    }
+
 
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/ClientSocketHandler.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/ClientSocketHandler.java
@@ -13,7 +13,7 @@ public class ClientSocketHandler extends Thread {
 
     private static final String TAG = "wifi_direct_c_handler";
     private Handler handler;
-    private GPSCommManager manager;
+    private CommManager manager;
     private InetAddress mAddress;
 
     public ClientSocketHandler(Handler handler, InetAddress groupOwnerAddress) {
@@ -39,7 +39,7 @@ public class ClientSocketHandler extends Thread {
             socket.setReuseAddress(true);
             socket.connect(addr,WiFiDirectCommunicator.TIMEOUT);
             Log.d(TAG, "Launching the I/O handler");
-            manager = new GPSCommManager(socket, handler);
+            manager = new CommManager(socket, handler);
             new Thread(manager).start();
         } catch (IOException e) {
             e.printStackTrace();

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/CommManager.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/CommManager.java
@@ -73,6 +73,7 @@ public class CommManager implements Runnable {
     public void write(byte[] buffer) {
         try {
             oStream.write(buffer);
+            oStream.flush();
             Log.d(TAG,"write to buffer" + String.valueOf(buffer));
         } catch (IOException e) {
             Log.e(TAG, "Exception during write", e);

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/CommManager.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/CommManager.java
@@ -17,7 +17,7 @@ import java.net.Socket;
  * Handles reading and writing of messages with socket buffers. Uses a Handler
  * to post messages to UI thread for UI updates.
  */
-public class GPSCommManager implements Runnable {
+public class CommManager implements Runnable {
 
     private Socket socket = null;
     private Handler handler;
@@ -25,12 +25,11 @@ public class GPSCommManager implements Runnable {
     private OutputStream oStream;
     private static final String TAG = "wifi_direct_commanager";
 
-    public GPSCommManager(Socket socket, Handler handler) {
+    public CommManager(Socket socket, Handler handler) {
         this.socket = socket;
         this.handler = handler;
         Log.d(TAG,"instantiate");
     }
-
 
 
     @Override
@@ -55,8 +54,7 @@ public class GPSCommManager implements Runnable {
 
                     // Send the obtained bytes to the UI Activity
                     Log.d(TAG, "Rec:" + String.valueOf(buffer));
-                    handler.obtainMessage(WiFiDirectCommunicator.MESSAGE_READ,
-                            bytes, -1, buffer).sendToTarget();
+                    handler.obtainMessage(WiFiDirectCommunicator.MESSAGE_READ,bytes, -1, buffer).sendToTarget();
                 } catch (IOException e) {
                     Log.e(TAG, "disconnected", e);
                 }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/CommManager.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/CommManager.java
@@ -53,7 +53,7 @@ public class CommManager implements Runnable {
                     }
 
                     // Send the obtained bytes to the UI Activity
-                    Log.d(TAG, "Rec:" + String.valueOf(buffer));
+                    Log.d(TAG, "received :" + String.valueOf(buffer));
                     handler.obtainMessage(WiFiDirectCommunicator.MESSAGE_READ,bytes, -1, buffer).sendToTarget();
                 } catch (IOException e) {
                     Log.e(TAG, "disconnected", e);

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/GroupOwnerSocketHandler.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/GroupOwnerSocketHandler.java
@@ -54,7 +54,7 @@ public class GroupOwnerSocketHandler extends Thread {
                 // there is a new connection
                 //pool.execute(new GPSCommManager(server_socket.accept(), handler));
                 Socket socket = server_socket.accept(); // blocking method. The Program stops until a connection request is received from the client.
-                new Thread(new GPSCommManager(socket, handler)).start();
+                new Thread(new CommManager(socket, handler)).start();
                 Log.d(TAG, "Launching the I/O handler");
 
             } catch (IOException e) {

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/HeartBeatTask.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/HeartBeatTask.java
@@ -8,14 +8,15 @@ import android.os.Handler;
  */
 
 public class HeartBeatTask implements Runnable {
-    static boolean respond = true;
-    static final int INTERVAL = 2500;
+    static boolean respond;
+    static final int INTERVAL = 5000;
     WiFiDirectCommunicator communicator;
     Handler handler;
 
     HeartBeatTask(WiFiDirectCommunicator communicator, Handler handler){
         this.communicator = communicator;
         this.handler = handler;
+        this.respond = true;
     }
 
     @Override

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/HeartBeatTask.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/HeartBeatTask.java
@@ -9,7 +9,7 @@ import android.os.Handler;
 
 public class HeartBeatTask implements Runnable {
     static boolean respond;
-    static final int INTERVAL = 5000;
+    static final int INTERVAL = 8000;
     WiFiDirectCommunicator communicator;
     Handler handler;
 

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/HeartBeatTask.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/HeartBeatTask.java
@@ -1,27 +1,32 @@
 package jp.enpitsu.paseri.syugo.WiFiDirect;
 
 import java.util.TimerTask;
+import android.os.Handler;
 
 /**
  * Created by Prily on 2016/12/06.
  */
 
-public class HeartBeatTask extends TimerTask {
+public class HeartBeatTask implements Runnable {
     static boolean respond = true;
+    static final int INTERVAL = 2500;
     WiFiDirectCommunicator communicator;
+    Handler handler;
 
-    HeartBeatTask(WiFiDirectCommunicator communicator){
+    HeartBeatTask(WiFiDirectCommunicator communicator, Handler handler){
         this.communicator = communicator;
+        this.handler = handler;
     }
 
     @Override
     public void run() {
         // send Heartbeat
         if (respond){
-            communicator.sendHeartBeat();
+            communicator.sendPing();
             respond = false;
+            handler.postDelayed(this,INTERVAL);
         }else{
-            this.cancel();
+            communicator.socketNotResponding();
         }
     }
 }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/HeartBeatTask.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/HeartBeatTask.java
@@ -1,0 +1,27 @@
+package jp.enpitsu.paseri.syugo.WiFiDirect;
+
+import java.util.TimerTask;
+
+/**
+ * Created by Prily on 2016/12/06.
+ */
+
+public class HeartBeatTask extends TimerTask {
+    static boolean respond = true;
+    WiFiDirectCommunicator communicator;
+
+    HeartBeatTask(WiFiDirectCommunicator communicator){
+        this.communicator = communicator;
+    }
+
+    @Override
+    public void run() {
+        // send Heartbeat
+        if (respond){
+            communicator.sendHeartBeat();
+            respond = false;
+        }else{
+            this.cancel();
+        }
+    }
+}

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
@@ -21,7 +21,7 @@ import jp.enpitsu.paseri.syugo.Rader.LocationData;
     0x02 Audio
     0x0F HeartBeat
 
-    # DATA FORMAT (excepting Heartbeat)
+    # DATA FORMAT (except Heartbeat)
     1 byte : type(code)
     4 byte : byte length
     n byte : data
@@ -32,8 +32,11 @@ import jp.enpitsu.paseri.syugo.Rader.LocationData;
 public final class Serializer {
     static final byte CHAT = 0x00;
     static final byte LOCATION = 0x01;
-    static final byte HEARTBEAT = 0x0F;
-    static final byte[] ping = {HEARTBEAT};
+    static final byte PING = 0x0F;
+    static final byte ACK = 0x0E;
+    static final byte[] ping = {PING};
+    static final byte[] ack = {ACK};
+
 
 
     /* ---------------
@@ -82,7 +85,9 @@ public final class Serializer {
                 buffer.get(data, 0, len);
                 LocationData loc = new LocationData(data);
                 return new Pair<Byte, Object>(code, (Object) loc);
-            case HEARTBEAT:
+            case PING:
+                return new Pair<Byte, Object>(code, null);
+            case ACK:
                 return new Pair<Byte, Object>(code, null);
             default:
                 Log.e("wifi_direct_serializer", "Unknown type error");

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
@@ -15,10 +15,16 @@ import jp.enpitsu.paseri.syugo.Rader.LocationData;
 
 
 /*
-    1 byte : type(code) (0x00 = String , 0x01 = LocationData)
+    # CODE
+    0x00 String
+    0x01 LocationData
+    0x02 Audio
+    0x0F HeartBeat
+
+    # DATA FORMAT (excepting Heartbeat)
+    1 byte : type(code)
     4 byte : byte length
     n byte : data
-
  */
 
 

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
@@ -42,7 +42,7 @@ public final class Serializer {
     }
 
     static private byte[] construction(byte code, byte[] bytes){
-        int size = Byte.SIZE + Integer.SIZE + bytes.length;
+        int size = Byte.SIZE/8 + Integer.SIZE/8 + bytes.length;
         ByteBuffer buffer = ByteBuffer.allocate(size);
         buffer.clear();
         buffer.put(code);

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
@@ -14,6 +14,14 @@ import jp.enpitsu.paseri.syugo.Rader.LocationData;
  */
 
 
+/*
+    1 byte : type(code) (0x00 = String , 0x01 = LocationData)
+    4 byte : byte length
+    n byte : data
+
+ */
+
+
 // Static Class
 public final class Serializer {
     static final byte CHAT = 0x00;
@@ -34,10 +42,11 @@ public final class Serializer {
     }
 
     static private byte[] construction(byte code, byte[] bytes){
-        int size = bytes.length + Character.SIZE;
+        int size = Byte.SIZE + Integer.SIZE + bytes.length;
         ByteBuffer buffer = ByteBuffer.allocate(size);
         buffer.clear();
         buffer.put(code);
+        buffer.putInt(bytes.length);
         buffer.put(bytes);
         return buffer.array();
     };
@@ -47,19 +56,17 @@ public final class Serializer {
     -------------- */
 
     static public Pair<Byte,Object> Decode(byte[] bytes) {
-        int len = bytes.length;
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         byte code = buffer.get();
+        int len = buffer.getInt();
+        byte[] data = new byte[len];
+        buffer.get(data, 0, len);
         switch (code) {
             case CHAT:
-                byte[] str_bytes = new byte[len - 1];
-                buffer.get(str_bytes, 1, len - 1);
-                String str = new String(str_bytes);
+                String str = new String(data);
                 return new Pair<Byte, Object>(code, (Object) str);
             case LOCATION:
-                byte[] loc_bytes = new byte[len - 1];
-                buffer.get(loc_bytes, 1, len - 1);
-                LocationData loc = new LocationData(loc_bytes);
+                LocationData loc = new LocationData(data);
                 return new Pair<Byte, Object>(code, (Object) loc);
             default:
                 Log.e("wifi_direct_serializer", "Unknown type error");

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
@@ -26,6 +26,9 @@ import jp.enpitsu.paseri.syugo.Rader.LocationData;
 public final class Serializer {
     static final byte CHAT = 0x00;
     static final byte LOCATION = 0x01;
+    static final byte HEARTBEAT = 0x0F;
+    static final byte[] ping = {HEARTBEAT};
+
 
     /* ---------------
         Encoder
@@ -57,17 +60,24 @@ public final class Serializer {
 
     static public final Pair<Byte,Object> Decode(byte[] bytes) {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        int len;
+        byte[] data;
         byte code = buffer.get();
-        int len = buffer.getInt();
-        byte[] data = new byte[len];
-        buffer.get(data, 0, len);
         switch (code) {
             case CHAT:
+                len = buffer.getInt();
+                data = new byte[len];
+                buffer.get(data, 0, len);
                 String str = new String(data);
                 return new Pair<Byte, Object>(code, (Object) str);
             case LOCATION:
+                len = buffer.getInt();
+                data = new byte[len];
+                buffer.get(data, 0, len);
                 LocationData loc = new LocationData(data);
                 return new Pair<Byte, Object>(code, (Object) loc);
+            case HEARTBEAT:
+                return new Pair<Byte, Object>(code, null);
             default:
                 Log.e("wifi_direct_serializer", "Unknown type error");
                 return null;

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
@@ -31,17 +31,17 @@ public final class Serializer {
         Encoder
     -------------- */
 
-    static public byte[] Encode(String str){
+    static public final byte[] Encode(String str){
         byte code = CHAT;
         return construction(code,str.getBytes());
     }
 
-    static public byte[] Encode(LocationData loc){
+    static public final byte[] Encode(LocationData loc){
         byte code = LOCATION;
         return construction(code,loc.getBytes());
     }
 
-    static private byte[] construction(byte code, byte[] bytes){
+    static private final byte[] construction(byte code, byte[] bytes){
         int size = Byte.SIZE/8 + Integer.SIZE/8 + bytes.length;
         ByteBuffer buffer = ByteBuffer.allocate(size);
         buffer.clear();
@@ -55,7 +55,7 @@ public final class Serializer {
         Decoder
     -------------- */
 
-    static public Pair<Byte,Object> Decode(byte[] bytes) {
+    static public final Pair<Byte,Object> Decode(byte[] bytes) {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         byte code = buffer.get();
         int len = buffer.getInt();

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/Serializer.java
@@ -1,0 +1,69 @@
+package jp.enpitsu.paseri.syugo.WiFiDirect;
+
+import android.location.Location;
+import android.net.wifi.p2p.WifiP2pDevice;
+import android.util.Log;
+import android.util.Pair;
+
+import java.nio.ByteBuffer;
+
+import jp.enpitsu.paseri.syugo.Rader.LocationData;
+
+/**
+ * Created by Prily on 2016/12/06.
+ */
+
+
+// Static Class
+public final class Serializer {
+    static final byte CHAT = 0x00;
+    static final byte LOCATION = 0x01;
+
+    /* ---------------
+        Encoder
+    -------------- */
+
+    static public byte[] Encode(String str){
+        byte code = CHAT;
+        return construction(code,str.getBytes());
+    }
+
+    static public byte[] Encode(LocationData loc){
+        byte code = LOCATION;
+        return construction(code,loc.getBytes());
+    }
+
+    static private byte[] construction(byte code, byte[] bytes){
+        int size = bytes.length + Character.SIZE;
+        ByteBuffer buffer = ByteBuffer.allocate(size);
+        buffer.clear();
+        buffer.put(code);
+        buffer.put(bytes);
+        return buffer.array();
+    };
+
+    /* ---------------
+        Decoder
+    -------------- */
+
+    static public Pair<Byte,Object> Decode(byte[] bytes) {
+        int len = bytes.length;
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        byte code = buffer.get();
+        switch (code) {
+            case CHAT:
+                byte[] str_bytes = new byte[len - 1];
+                buffer.get(str_bytes, 1, len - 1);
+                String str = new String(str_bytes);
+                return new Pair<Byte, Object>(code, (Object) str);
+            case LOCATION:
+                byte[] loc_bytes = new byte[len - 1];
+                buffer.get(loc_bytes, 1, len - 1);
+                LocationData loc = new LocationData(loc_bytes);
+                return new Pair<Byte, Object>(code, (Object) loc);
+            default:
+                Log.e("wifi_direct_serializer", "Unknown type error");
+                return null;
+        }
+    }
+}

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
@@ -159,6 +159,10 @@ public class WiFiDirect {
         activity.unregisterReceiver(receiver);
     }
 
+    public void onDestroy(){
+        endConnection();
+    }
+
     /* -----------------------------------------------------------
     Catch status by BroadcastReceiver : notify us wifip2p & device status
     -------------------------------------------------------------- */
@@ -209,7 +213,6 @@ public class WiFiDirect {
             // Turn on the light
             controlWfdButton(ButtonCmd.ON);
         }else{
-            toast("Socket切断したよ");
             // Turn off the light
             controlWfdButton(ButtonCmd.OFF);
         }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
@@ -443,7 +443,7 @@ public class WiFiDirect {
     Communication
     -------------------------------------------------------------- */
 
-    public void sendMessage(String str){
+    public void sendChat(String str){
         if(communicator!=null){
             communicator.sendChat(str);
         }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
@@ -212,9 +212,11 @@ public class WiFiDirect {
             toast("Socket接続完了！");
             // Turn on the light
             controlWfdButton(ButtonCmd.ON);
-        }else{
+        }else if (str.equals("unconnected")){
             // Turn off the light
             controlWfdButton(ButtonCmd.OFF);
+        }else if (str.equals("disconnected")){
+            endConnection();
         }
     }
 

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
@@ -445,7 +445,7 @@ public class WiFiDirect {
 
     public void sendMessage(String str){
         if(communicator!=null){
-            communicator.sendMessage(str);
+            communicator.sendChat(str);
         }
     }
 
@@ -454,5 +454,4 @@ public class WiFiDirect {
             communicator.sendGPSLocation(loc);
         }
     }
-
 }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
@@ -34,6 +34,7 @@ import android.net.wifi.p2p.WifiP2pManager.ChannelListener;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.util.Log;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -389,6 +390,7 @@ public class WiFiDirect {
             wfd_toast.cancel();
         }
         wfd_toast = Toast.makeText(activity, str, Toast.LENGTH_SHORT);
+        wfd_toast.setGravity(Gravity.CENTER,0,0);
         wfd_toast.show();
     }
 

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
@@ -21,6 +21,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.location.Location;
 import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.net.wifi.p2p.WifiP2pConfig;
@@ -54,6 +55,7 @@ import java.lang.reflect.Method;
 
 import jp.enpitsu.paseri.syugo.Global.SyugoApp;
 import jp.enpitsu.paseri.syugo.R;
+import jp.enpitsu.paseri.syugo.Rader.LocationData;
 
 import static android.os.Looper.getMainLooper;
 import static android.webkit.ConsoleMessage.MessageLevel.LOG;
@@ -436,4 +438,21 @@ public class WiFiDirect {
             }
         }
     }
+
+    /* -----------------------------------------------------------
+    Communication
+    -------------------------------------------------------------- */
+
+    public void sendMessage(String str){
+        if(communicator!=null){
+            communicator.sendMessage(str);
+        }
+    }
+
+    public void sendGPSLocation(LocationData loc){
+        if(communicator!=null){
+            communicator.sendGPSLocation(loc);
+        }
+    }
+
 }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
@@ -378,7 +378,7 @@ public class WiFiDirect {
     Notify
     -------------------------------------------------------------- */
 
-    protected void toast(String str){
+    public void toast(String str){
         if(wfd_toast!=null) {
             wfd_toast.cancel();
         }
@@ -452,6 +452,12 @@ public class WiFiDirect {
     public void sendGPSLocation(LocationData loc){
         if(communicator!=null){
             communicator.sendGPSLocation(loc);
+        }
+    }
+
+    public void setWiFiDirectEventListener(WiFiDirectEventListener listener){
+        if(communicator!=null){
+            communicator.listener = listener;
         }
     }
 }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirect.java
@@ -216,6 +216,7 @@ public class WiFiDirect {
             // Turn off the light
             controlWfdButton(ButtonCmd.OFF);
         }else if (str.equals("disconnected")){
+            toast("相手端末と通信隔絶…");
             endConnection();
         }
     }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
@@ -100,16 +100,19 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
                 switch(decoded.first){
                     case Serializer.CHAT:
                         String str = (String)decoded.second;
-                        if (listener!=null) listener.receiveChat(str);
+                        if (listener!=null) {
+                            listener.receiveChat(str);
+                        }
                         break;
                     case Serializer.LOCATION:
                         LocationData loc = (LocationData)decoded.second;
-                        if (listener!=null) listener.receiveGPSLocation(loc);
+                        if (listener!=null) {
+                            listener.receiveGPSLocation(loc);
+                        }
                         break;
                     default:
                         Log.e(TAG,"unknown type");
                 }
-                Log.d(TAG, readBuf.toString());
                 break;
 
             case MY_HANDLE:

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
@@ -11,6 +11,8 @@ import android.view.View;
 import android.widget.EditText;
 
 import java.io.IOException;
+import java.util.Timer;
+import java.util.TimerTask;
 
 import jp.enpitsu.paseri.syugo.Rader.LocationData;
 
@@ -52,6 +54,7 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
     WiFiDirect wfd;
     CommManager manager;
     WiFiDirectEventListener listener;
+    HeartBeatTask heartBeatTask;
 
     WiFiDirectCommunicator(WiFiDirect wfd){
         this.wfd = wfd;
@@ -110,6 +113,12 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
                             listener.receiveGPSLocation(loc);
                         }
                         break;
+                    case Serializer.HEARTBEAT:
+                        if(heartBeatTask!=null){
+                            heartBeatTask.respond = true;
+                            sendHeartBeat();
+                            Log.d(TAG,"heart-beat");
+                        }
                     default:
                         Log.e(TAG,"unknown type");
                 }
@@ -120,8 +129,15 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
                 manager = (CommManager) obj;
                 Log.d(TAG, "manager obj received");
                 wfd.setSocketConnection("connected");
+                startHeartBeat();
         }
         return true;
+    }
+
+    public void startHeartBeat(){
+        Timer timer = new Timer();
+        heartBeatTask = new HeartBeatTask(this);
+        timer.schedule(heartBeatTask, 1000, 1000);
     }
 
     // send message

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
@@ -101,10 +101,13 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
                     case Serializer.CHAT:
                         String str = (String)decoded.second;
                         if (listener!=null) listener.receiveChat(str);
-
+                        break;
                     case Serializer.LOCATION:
                         LocationData loc = (LocationData)decoded.second;
                         if (listener!=null) listener.receiveGPSLocation(loc);
+                        break;
+                    default:
+                        Log.e(TAG,"unknown type");
                 }
                 Log.d(TAG, readBuf.toString());
                 break;

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
@@ -141,6 +141,14 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
         }
     }
 
+    public void sendHeartBeat(){
+        if (manager != null) {
+            manager.write(Serializer.ping);
+        }else{
+            socketFailed();
+        }
+    }
+
     private void socketFailed(){
         Log.d(TAG,"manager is null");
         wfd.setSocketConnection("disconnected");

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
@@ -10,6 +10,8 @@ import android.widget.EditText;
 
 import java.io.IOException;
 
+import jp.enpitsu.paseri.syugo.Rader.LocationData;
+
 /**
  * Created by Prily on 2016/11/24.
  */
@@ -46,7 +48,7 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
     public static final int MY_HANDLE = 0x400 + 2;
 
     WiFiDirect wfd;
-    GPSCommManager manager;
+    CommManager manager;
 
     WiFiDirectCommunicator(WiFiDirect wfd){
         this.wfd = wfd;
@@ -99,7 +101,7 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
 
             case MY_HANDLE:
                 Object obj = msg.obj;
-                manager = (GPSCommManager) obj;
+                manager = (CommManager) obj;
                 Log.d(TAG, "manager obj received");
                 wfd.setSocketConnection("connected");
         }
@@ -110,6 +112,15 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
     public void sendMessage(String str){
         if (manager != null) {
             manager.write(str.getBytes());
+        }else{
+            Log.d(TAG,"manager is null");
+            wfd.setSocketConnection("disconnected");
+        }
+    }
+
+    public void sendGPSLocation(LocationData loc){
+        if (manager != null) {
+
         }else{
             Log.d(TAG,"manager is null");
             wfd.setSocketConnection("disconnected");

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
@@ -142,7 +142,7 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
     public void startHeartBeat(){
         Handler handler = new Handler();
         heartBeatTask = new HeartBeatTask(this,handler);
-        handler.postDelayed(heartBeatTask,HeartBeatTask.INTERVAL);
+        handler.postDelayed(heartBeatTask,HeartBeatTask.INTERVAL*2);
     }
 
     // send message

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectCommunicator.java
@@ -51,6 +51,7 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
 
     WiFiDirect wfd;
     CommManager manager;
+    WiFiDirectEventListener listener;
 
     WiFiDirectCommunicator(WiFiDirect wfd){
         this.wfd = wfd;
@@ -99,11 +100,11 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
                 switch(decoded.first){
                     case Serializer.CHAT:
                         String str = (String)decoded.second;
-                        //receiveChat(str);
+                        if (listener!=null) listener.receiveChat(str);
 
                     case Serializer.LOCATION:
                         LocationData loc = (LocationData)decoded.second;
-                        //receiveGPSLocation(loc);
+                        if (listener!=null) listener.receiveGPSLocation(loc);
                 }
                 Log.d(TAG, readBuf.toString());
                 break;
@@ -138,5 +139,4 @@ public class WiFiDirectCommunicator implements WifiP2pManager.ConnectionInfoList
         Log.d(TAG,"manager is null");
         wfd.setSocketConnection("disconnected");
     }
-
 }

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectEventListener.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/WiFiDirect/WiFiDirectEventListener.java
@@ -1,0 +1,14 @@
+package jp.enpitsu.paseri.syugo.WiFiDirect;
+
+import java.util.EventListener;
+
+import jp.enpitsu.paseri.syugo.Rader.LocationData;
+
+/**
+ * Created by Prily on 2016/12/06.
+ */
+
+public interface WiFiDirectEventListener extends EventListener {
+    public void receiveChat(String str);
+    public void receiveGPSLocation(LocationData loc);
+}

--- a/Syugo/app/src/main/res/layout/activity_secret.xml
+++ b/Syugo/app/src/main/res/layout/activity_secret.xml
@@ -7,11 +7,18 @@
     android:weightSum="1">
 
     <Button
-        android:text="ping"
+        android:text="chat"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:id="@+id/sc_ping"
-        android:layout_weight="0.12" />
+        android:id="@+id/sc_chat"
+        android:layout_weight="0.06" />
+
+    <Button
+        android:text="location"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/sc_loc"
+        android:layout_weight="0.06" />
 
     <ToggleButton
         android:text="ToggleButton"

--- a/Syugo/app/src/main/res/layout/activity_secret.xml
+++ b/Syugo/app/src/main/res/layout/activity_secret.xml
@@ -7,10 +7,11 @@
     android:weightSum="1">
 
     <Button
-        android:text="データのリセット"
+        android:text="ping"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:id="@+id/sc_data_reset" />
+        android:id="@+id/sc_ping"
+        android:layout_weight="0.12" />
 
     <ToggleButton
         android:text="ToggleButton"


### PR DESCRIPTION
①GPS用/チャット用のAPIと内部プロトコル追加
送信：
sendChat, sendGPSLocation　とかをつかってね
受信：
setWiFiDirectEventListenerクラスのインスタンスを作って登録

②LocationDataクラスを拡張しました（シリアライザ用）
かくにんおねがいします！ぱせさん

③死活監視の仕組みを追加
お互いが死活監視用のパケットを交換し続けます
一定時間たっても応答が無ければ切断

④問題
レーダーと同じスレッドで動いているのでこまることがある
・レーダーがハングすると死活パケットに応答を返せなくて切断する
　　→条件をゆるくすればなんとかなるかも
・GPS情報のやりとりの頻度を挙げすぎるとたぶんハングする
　　→今かなり無駄の多い実装，速くすることはできる


叩き方等はSecretActivityがデモになっているのでそちらを見るとはやいかも！


