### PR TITLE
LookActivity, RegActivity例外処理の追加

### DIFF
--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Lookfor/LookActivity.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Lookfor/LookActivity.java
@@ -121,47 +121,54 @@ public class LookActivity extends Activity {
     // コードでユーザー検索"name,mac"
     private View.OnClickListener searchListener = new View.OnClickListener() {
         public void onClick(View v) {
-            reqID = id.getText().toString(); // 相手ID入力テキストボックスから相手のID取得
-            id2.setText( reqID ); // 入力された相手IDをメッセージ部分に表示
-            HttpComLookFor httpComLookFor = new HttpComLookFor(
-                    new HttpComLookFor.AsyncTaskCallback() {
-                        @Override
-                        public void postExecute(String result) {
+
+            if ( TextUtils.isEmpty( id.getText().toString() ) == false ) { // 検索するIDが入力されている場合
+                reqID = id.getText().toString(); // 相手ID入力テキストボックスから相手のID取得
+
+                if ( reqID.equals( app.getSelfUserId() ) ) { // 自分のIDが入力されている場合
+                    e_message.setText("自分のIDが入力されています。正しいIDを入力して下さい。");
+                    return;
+                }
+
+                id2.setText(reqID); // 入力された相手IDをメッセージ部分に表示
+                HttpComLookFor httpComLookFor = new HttpComLookFor(
+                        new HttpComLookFor.AsyncTaskCallback() {
+                            @Override
+                            public void postExecute(String result) {
 //                            // 検索結果として"0"が返ってきた場合，ふつうに出力すると"0"だけどbyteとかlengthとか見ると別のものもくっついてるっぽい
 //                            // のでID検索一致0の場合の判定で妙なことしてます
 //                            Log.d("result byte  ", result.getBytes() + ", " + "0".getBytes() );
 //                            Log.d("result length", "" + result.length() );
 //                            Log.d("result char  ", (int)result.charAt(0) + ", " + (int)result.charAt(1) + " : " + (int)'0' );
 
-                            if( "error".equals( result ) ) { // サーバ側の不具合で検索に失敗した場合"error"が入ってる
-                                name.setText( "接続エラー" );
-                            }
-                            else if( '0' == result.charAt(1) ) { // reqIDに一致するIDのユーザ名が見つからなかった場合
-                                name.setText( "失敗" );
-                            }
-                            else {
-                                try {
-                                    // resultは「相手のユーザ名,MACアドレス」の形で返ってくる
-                                    oppName = result.substring(1, result.indexOf(",") + 0);
-                                    // 最初から","が現れるまでの部分文字列(なんか先頭文字に改行が入ってるっぽいのでインデックス1～を指定)
-                                    macAdr = result.substring(result.indexOf(",") + 1, result.length());
-                                    // ","の次の文字から最後までの部分文字列
-                                    name.setText(oppName); // [検索結果]相手のユーザ名を表示
-                                    app.setOpponentUserInfo(oppName, reqID);
-                                    app.saveUserInfo();
-                                    Log.d("PrilyClass_name", app.getOpponentUserName());
-                                    Log.d("PrilyClass_id", app.getOpponentUserId());
-                                } catch ( Exception e ) {
-                                    name.setText( result );
-                                    Log.d("@LookActivity", "postExecute -> error:" + e.toString() );
+                                if ("error".equals(result)) { // サーバ側の不具合で検索に失敗した場合"error"が入ってる
+                                    name.setText("接続エラー");
+                                } else if ('0' == result.charAt(1)) { // reqIDに一致するIDのユーザ名が見つからなかった場合
+                                    name.setText("失敗");
+                                } else {
+                                    try {
+                                        // resultは「相手のユーザ名,MACアドレス」の形で返ってくる
+                                        oppName = result.substring(1, result.indexOf(",") + 0);
+                                        // 最初から","が現れるまでの部分文字列(なんか先頭文字に改行が入ってるっぽいのでインデックス1～を指定)
+                                        macAdr = result.substring(result.indexOf(",") + 1, result.length());
+                                        // ","の次の文字から最後までの部分文字列
+                                        name.setText(oppName); // [検索結果]相手のユーザ名を表示
+                                        app.setOpponentUserInfo(oppName, reqID);
+                                        app.saveUserInfo();
+                                        Log.d("PrilyClass_name", app.getOpponentUserName());
+                                        Log.d("PrilyClass_id", app.getOpponentUserId());
+                                    } catch (Exception e) {
+                                        name.setText(result);
+                                        Log.d("@LookActivity", "postExecute -> error:" + e.toString());
+                                    }
                                 }
                             }
                         }
-                    }
-            );
-            httpComLookFor.setUserInfo( reqID );
-            httpComLookFor.executeOnExecutor( AsyncTask.THREAD_POOL_EXECUTOR );
-        }
+                );
+                httpComLookFor.setUserInfo(reqID);
+                httpComLookFor.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+            } // if ( TextUtils.isEmpty(oppName) == false )...
+        }  // onClick
     };
 
     //検索ボタン押してマップ画面へ

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Lookfor/LookActivity.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Lookfor/LookActivity.java
@@ -121,7 +121,7 @@ public class LookActivity extends Activity {
     // コードでユーザー検索"name,mac"
     private View.OnClickListener searchListener = new View.OnClickListener() {
         public void onClick(View v) {
-
+            e_message.setText( "" );
             if ( TextUtils.isEmpty( id.getText().toString() ) == false ) { // 検索するIDが入力されている場合
                 reqID = id.getText().toString(); // 相手ID入力テキストボックスから相手のID取得
 
@@ -168,6 +168,9 @@ public class LookActivity extends Activity {
                 httpComLookFor.setUserInfo(reqID);
                 httpComLookFor.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
             } // if ( TextUtils.isEmpty(oppName) == false )...
+            else {
+                e_message.setText( "IDを入力してください。" );
+            }
         }  // onClick
     };
 

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Registor/RegActivity.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Registor/RegActivity.java
@@ -160,6 +160,11 @@ public class RegActivity extends Activity {
                             public void postExecute(String result) {
                                 myID = result.replaceAll("\n", "");
                                 text_idshow.setText(myID);
+                                if ( myID.equals( "error" ) ) {
+                                    error_message.setText("ID発行エラー\n" +
+                                            "通信環境を見直し、再度[REGISTER]ボタンを押してみてください。");
+                                    return;
+                                }
                                 app.setSelfUserInfo(user_name,myID);
                                 app.saveUserInfo();
                                 Log.d("PrilyClass_name",app.getSelfUserName());

--- a/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Registor/RegActivity.java
+++ b/Syugo/app/src/main/java/jp/enpitsu/paseri/syugo/Registor/RegActivity.java
@@ -162,7 +162,8 @@ public class RegActivity extends Activity {
                                 text_idshow.setText(myID);
                                 if ( myID.equals( "error" ) ) {
                                     error_message.setText("ID発行エラー\n" +
-                                            "通信環境を見直し、再度[REGISTER]ボタンを押してみてください。");
+                                            "通信環境を見直し、再度[REGISTER]ボタンを\n押してみてください。");
+                                    myID = null;
                                     return;
                                 }
                                 app.setSelfUserInfo(user_name,myID);
@@ -181,7 +182,7 @@ public class RegActivity extends Activity {
                     error_message.setText("YourNameが入力されていません．");
                     Log.d("RegActivity", "UserName is null.");
                 }
-                else if(TextUtils.isEmpty(myID) == false) {
+                else if(TextUtils.isEmpty(myID) == false ) {
                     error_message.setText("IDはすでに発行されています．");
                     Log.d("RegActivity", "UserID is showed already.");
                 }

--- a/Syugo/app/src/main/res/layout/activity_reg.xml
+++ b/Syugo/app/src/main/res/layout/activity_reg.xml
@@ -59,7 +59,7 @@
         <Button
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="REGISTOR"
+            android:text="REGISTER"
             android:id="@+id/button_issue"
             android:textColor="@color/colorWhite"
             android:textSize="25dp"


### PR DESCRIPTION
**LookActivity**
自分のIDを検索してそのまんまレーダー画面に進める問題
→自分のID入力された状態で[SEARCH]ボタン押されたらエラーメッセージ表示，ID検索を実行しないようにした


**RegActivity**
ID発行で"error"が返ってきた場合（うっかり機内モードでID発行しようとした）そのままデータ管理クラスに登録されてしまうのでその辺改善したつもり．